### PR TITLE
[BUGFIX] Clean exec output before usage to avoid duplicate output

### DIFF
--- a/magento_appsec_file_check.php
+++ b/magento_appsec_file_check.php
@@ -105,6 +105,7 @@ function doExec($_securityNotice,$_appsec)
 		foreach ($_securityNotice['exec']['query'] as $_searchQuery)
 		{
 
+            $_output = array();
 			exec($_exec. $_searchQuery. ' '. $_searchPath, $_output, $_status);
 			
 			if (1 === $_status)


### PR DESCRIPTION
When an exec for an APPSEC check returns results for multiple paths or queries, the output of previous results is appended to the new results. This results in duplicate output.

This PR fixes this issue.
